### PR TITLE
Generator example is completely lazy

### DIFF
--- a/doc/01-generators.md
+++ b/doc/01-generators.md
@@ -12,7 +12,7 @@ First, let's define a dynamic var to hold the thread-local context keeping track
 (def ^:dynamic *tail*)
 
 (defn gen-seq [gen]
-  (binding [*tail* (lazy-seq (gen-seq gen))] (gen)))
+  (lazy-seq (binding [*tail* (gen-seq gen)] (gen))))
 ```
 
 


### PR DESCRIPTION
In the given Generator example implementation, the generator strictly evaluates up until and including the first element as soon as it's deefined. For instance

```clojure
(def foo (generate (println "hi") (yield 1)))
;; "hi" is printed already, before forcing foo
```
Now, with the proposed changes, the generator is completely lazy, including the first element.