### PR TITLE
FEAT: Remove Clojurescript requirement #21

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,17 +1,18 @@
 {:deps
- {org.clojure/clojure            {:mvn/version "1.11.1"}
-  org.clojure/clojurescript      {:mvn/version "1.11.60"}
-  org.clojure/tools.analyzer.jvm {:mvn/version "1.2.3"}}
+ {org.clojure/tools.analyzer.jvm {:mvn/version "1.2.3"}}
 
  :aliases
- {:clj-test
+ {:dev {:extra-paths ["test"]
+        :extra-deps {org.clojure/clojurescript {:mvn/version "1.11.60"}}}
+
+  :clj-test
   {:extra-deps  {io.github.cognitect-labs/test-runner
                  {:git/tag "v0.5.0" :git/sha "b3fd0d2"}}
    :extra-paths ["test"]
    :main-opts   ["-m" "cognitect.test-runner"]}
 
   :cljs-test
-  {:extra-deps  {olical/cljs-test-runner
-                 {:mvn/version "3.8.0"}}
+  {:extra-deps  {olical/cljs-test-runner {:mvn/version "3.8.0"}
+                 org.clojure/clojurescript {:mvn/version "1.11.60"}}
    :extra-paths ["test" "cljs-test-runner-out/gen"]
    :main-opts   ["-m" "cljs-test-runner.main"]}}}

--- a/src/cloroutine/impl/analyze_clj.clj
+++ b/src/cloroutine/impl/analyze_clj.clj
@@ -1,0 +1,18 @@
+(ns cloroutine.impl.analyze-clj
+  (:require [clojure.tools.analyzer.jvm :as clj])
+  (:import (clojure.lang Compiler$LocalBinding)))
+
+(defn analyze [env form]
+  (binding [clj/run-passes clj/scheduled-default-passes]
+    (->> env
+         (into {} (map (fn [[symbol binding]]
+                         [symbol (or (when (instance? Compiler$LocalBinding binding)
+                                       (let [binding ^Compiler$LocalBinding binding]
+                                         {:op   :local
+                                          :tag  (when (.hasJavaClass binding)
+                                                  (some-> binding (.getJavaClass)))
+                                          :form symbol
+                                          :name symbol}))
+                                     binding)])))
+         (update (clj/empty-env) :locals merge)
+         (clj/analyze form))))

--- a/src/cloroutine/impl/analyze_cljs.cljc
+++ b/src/cloroutine/impl/analyze_cljs.cljc
@@ -1,0 +1,8 @@
+(ns cloroutine.impl.analyze-cljs
+  (:require [cljs.analyzer]
+            [cljs.env]))
+
+(defn analyze [env form]
+  (binding [cljs.env/*compiler* (or cljs.env/*compiler*
+                                    (cljs.env/default-compiler-env))]
+    (cljs.analyzer/analyze env form nil nil)))


### PR DESCRIPTION
Add two new namespaces to expose clj and cljs dedicated analyze functions. Refactor the main `analyze` function to dynamically test if Clojurescript is provided in a clj context, then choose a dedicated analyzer accordingly.